### PR TITLE
Fix issue handling falsy values

### DIFF
--- a/piera/piera.py
+++ b/piera/piera.py
@@ -192,7 +192,7 @@ class Hiera(object):
                 else:
                     return value
 
-        raise KeyError('No value found in the cache')
+        raise KeyError(key)
 
     def get(self, key, default=None, **kwargs):
         """

--- a/piera/piera.py
+++ b/piera/piera.py
@@ -192,6 +192,8 @@ class Hiera(object):
                 else:
                     return value
 
+        raise KeyError('No value found in the cache')
+
     def get(self, key, default=None, **kwargs):
         """
         Attempts to retrieve a hiera variable by fully resolving its location.
@@ -219,5 +221,8 @@ class Hiera(object):
                     paths.append(self.load_file(path + '.' + backend.NAME, backend))
 
         # Locate the value, or fail and return the default
-        return self.get_key(key, paths, ctx) or default
+        try:
+            return self.get_key(key, paths, ctx)
+        except KeyError:
+            return default
 

--- a/tests/data/level1/common.yaml
+++ b/tests/data/level1/common.yaml
@@ -2,3 +2,5 @@ test_literal: "%{literal('hi')}"
 test_scope: "%{scope('name')}"
 
 test_interpolate: 'this is interpolated: %{name}'
+
+test_empty_hash: {}

--- a/tests/test.py
+++ b/tests/test.py
@@ -85,6 +85,9 @@ class TestPiera(BaseTestPiera):
     def test_interpolate(self):
         self.assertEquals(self.hiera.get('test_interpolate'), 'this is interpolated: test')
 
+    def test_handles_empty_hash(self):
+        self.assertEquals(self.hiera.get('test_empty_hash'), {})
+
 if __name__ == "__main__":
     base = os.getcwd()
     os.chdir(os.path.dirname(os.path.realpath(__file__)))


### PR DESCRIPTION
Due to python's handling of falsy values in or statements, an empty dict
or list would be returned as the default value passed to the `get()`
method rather than the intended falsy value.

This fixes it by raising a KeyError rather than falling through in the
`get_key()` method.

Fixes #2.
