### PR TITLE
Enable testrunner from setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
     install_requires=requires,
     license='Apache 2.0',
     zip_safe=False,
+    test_suite='tests',
     classifiers=(
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',

--- a/tests/test.py
+++ b/tests/test.py
@@ -6,10 +6,13 @@ try:
 except ImportError:
     import io as StringIO
 
+current_dirname, _ = os.path.split(os.path.abspath(__file__))
+
 class BaseTestPiera(unittest.TestCase):
     def setUp(self):
-        self.base = os.getcwd()
-        self.hiera = piera.Hiera('hiera.yaml', name='test')
+        self.base = current_dirname
+        self.hiera = piera.Hiera(os.path.join(current_dirname, 'hiera.yaml'),
+                                 name='test')
 
     def tearDown(self):
         os.chdir(self.base)


### PR DESCRIPTION
setuptools has a test discovery functionality that we can use with:

``` bash
python setup.py test
```

Also 

``` bash
python test.py
```

is still possible from the tests folder
