### PR TITLE
Enable interpolation for prefixed facts

### DIFF
--- a/piera/piera.py
+++ b/piera/piera.py
@@ -3,8 +3,8 @@ from collections import OrderedDict
 
 from .backends import YAMLBackend, JSONBackend
 
-function = re.compile(r'''%\{(scope|hiera|literal|alias)\(['"]([^"']*)["']\)\}''')
-interpolate = re.compile(r'''%\{([^\}]*)\}''')
+function = re.compile(r'''%\{(scope|hiera|literal|alias)\(['"](?:::|)([^"']*)["']\)\}''')
+interpolate = re.compile(r'''%\{(?:::|)([^\}]*)\}''')
 rformat = re.compile(r'''%{(?:::|)([a-zA-Z_-|\d]+)}''')
 
 class Hiera(object):

--- a/tests/data/level1/common.yaml
+++ b/tests/data/level1/common.yaml
@@ -1,7 +1,9 @@
 test_literal: "%{literal('hi')}"
 test_scope: "%{scope('name')}"
+test_scope_ns: "%{scope('::name')}"
 
 test_interpolate: 'this is interpolated: %{name}'
+test_interpolate_ns: 'this is interpolated: %{::name}'
 
 test_empty_hash: {}
 test_empty_list: []

--- a/tests/test.py
+++ b/tests/test.py
@@ -81,9 +81,11 @@ class TestPiera(BaseTestPiera):
         # Test Scope
         self.assertEquals(self.hiera.get('test_scope'), 'test')
         self.assertEquals(self.hiera.get('test_scope', name='wat'), 'wat')
+        self.assertEquals(self.hiera.get('test_scope_ns', name='wat'), 'wat')
 
     def test_interpolate(self):
         self.assertEquals(self.hiera.get('test_interpolate'), 'this is interpolated: test')
+        self.assertEquals(self.hiera.get('test_interpolate_ns'), 'this is interpolated: test')
 
     def test_falsey_values(self):
         self.assertEquals(self.hiera.get('test_empty_hash'), {})


### PR DESCRIPTION
Puppet enable facts to be defined with two notation: `factname` and
`::factname`.
This change implements the latter.

refs
https://docs.puppetlabs.com/puppet/latest/reference/lang_facts_and_builtin_vars.html#historical-note-about-
https://docs.puppetlabs.com/hiera/3.0/variables.html#interpolating-normal-variables
https://docs.puppetlabs.com/hiera/3.0/variables.html#the-scope-lookup-function
