### PR TITLE
Support basic interpolation during merging

### DIFF
--- a/piera/piera.py
+++ b/piera/piera.py
@@ -190,12 +190,12 @@ class Hiera(object):
         if len(calls) == 1 and calls[0][0] == 'alias':
             if function.sub("", s) != "":
                 raise Exception("Alias can not be used for string interpolation: `{}`".format(s))
-            return self.get_key(calls[0][1], paths, context, merge)
+            return self.get_key(calls[0][1], paths, context, None)
 
         # Iterate over all function calls and string interpolate their resolved values
         for call, arg in calls:
             if call == 'hiera':
-                replace = self.get_key(arg, paths, context, merge)
+                replace = self.get_key(arg, paths, context, None)
             elif call == 'scope':
                 replace = context.get(arg)
             elif call == 'literal':

--- a/tests/data/level1/common.yaml
+++ b/tests/data/level1/common.yaml
@@ -34,3 +34,7 @@ test_hash_merge_a:
 test_hash_merge_b:
   a: 2
   b: 2
+
+test_interpolated_hash_merge:
+  a: "default-a-%{hiera('test_literal')}"
+  b: "default-b-%{hiera('test_literal')}"

--- a/tests/data/level1/test.yaml
+++ b/tests/data/level1/test.yaml
@@ -23,3 +23,6 @@ test_hash_merge_a:
 test_hash_merge_b:
   a: 1
   b: 1
+
+test_interpolated_hash_merge:
+  a: "override-a-%{hiera('test_literal')}"

--- a/tests/test.py
+++ b/tests/test.py
@@ -150,6 +150,9 @@ class TestPiera(BaseTestPiera):
         self.assertEqual(self.hiera.get('test_hash_merge_a', merge=dict), {'a': 1, 'b': 2})
         self.assertEqual(self.hiera.get('test_hash_merge_b', merge=dict), {'a': 1, 'b': 1})
 
+    def test_interpolated_merge(self):
+        self.assertEqual(self.hiera.get('test_interpolated_hash_merge', merge=dict), {'a': 'override-a-hi', 'b': 'default-b-hi'})
+
 if __name__ == "__main__":
     base = os.getcwd()
     os.chdir(os.path.dirname(os.path.realpath(__file__)))


### PR DESCRIPTION
When looking up a key, with merging enabled, piera seems crashes if the value being merged contains functions that need to be interpolated. 
This seems to be because the function resolution code uses the same merge object used for the original key lookup, as-well-as keys used in the functions. Since these are unrelated, the original merge object is not applicable for any other key that the function might reference.
This pull request breaks this link allowing basic interpolation (without merging inside the interpolation) to work.